### PR TITLE
Make it easier to find comment author urls

### DIFF
--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -153,7 +153,7 @@ class Hacks {
 				'<a href="#" class="comment-remove-url" data-comment-id="%d" aria-label="%s">%s</a>',
 				\esc_attr( (string) $comment_id ),
 				\esc_attr__( 'Remove URL from this comment', 'comment-hacks' ),
-				'<small style="font-size:70% !important;">'  . \esc_html__( 'Remove URL', 'comment-hacks' ) . ' ' . htmlentities( $comment->comment_author_url ) . '</small>'
+				'<small style="font-size:70% !important;">' . \esc_html__( 'Remove URL', 'comment-hacks' ) . ' ' . \htmlentities( $comment->comment_author_url ) . '</small>'
 			);
 		}
 

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -153,7 +153,7 @@ class Hacks {
 				'<a href="#" class="comment-remove-url" data-comment-id="%d" aria-label="%s">%s</a>',
 				\esc_attr( (string) $comment_id ),
 				\esc_attr__( 'Remove URL from this comment', 'comment-hacks' ),
-				\esc_html__( 'Remove URL', 'comment-hacks' )
+				\esc_html__( 'Remove URL', 'comment-hacks' ) . ' <code><small>' . htmlentities( $comment->comment_author_url ) . '</small></code>'
 			);
 		}
 

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -153,7 +153,7 @@ class Hacks {
 				'<a href="#" class="comment-remove-url" data-comment-id="%d" aria-label="%s">%s</a>',
 				\esc_attr( (string) $comment_id ),
 				\esc_attr__( 'Remove URL from this comment', 'comment-hacks' ),
-				\esc_html__( 'Remove URL', 'comment-hacks' ) . ' <code><small>' . htmlentities( $comment->comment_author_url ) . '</small></code>'
+				'<small style="font-size:70% !important;">'  . \esc_html__( 'Remove URL', 'comment-hacks' ) . ' ' . htmlentities( $comment->comment_author_url ) . '</small>'
 			);
 		}
 


### PR DESCRIPTION
When going through broken links you'd have to look in the source to find a broken comment author link, with this change, we display it so it's easier to find.